### PR TITLE
Fix#1:The underline is coming at the time of dropping pincode into "Enter your pincode" TextInputEditText

### DIFF
--- a/app/src/main/res/layout/activity_pin.xml
+++ b/app/src/main/res/layout/activity_pin.xml
@@ -56,6 +56,8 @@
         android:id="@+id/pin_edit_lyt"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
         android:layout_margin="25dp"
         app:counterEnabled="true"
         app:counterMaxLength="6"


### PR DESCRIPTION
### Now the underline is not coming at the time of dropping Pincode into "Enter your pincode" TextInputEditText 

**Before:**
![underline](https://user-images.githubusercontent.com/99060332/212416302-9a573346-42c5-45ab-bdb0-11b2082d4903.jpg)

**After:**
![unde](https://user-images.githubusercontent.com/99060332/212416442-bc6d23c5-4128-4eb8-9b91-73f80862253f.jpeg)
